### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,13 @@ set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extens
 set(EXTENSION_CATEGORY "Diffusion")
 set(EXTENSION_CONTRIBUTORS "Antonio Carlos Senra Filho (University of Campinas, Brazil), Andre M. Paschoal (University of Campinas, Brazil), Luiz Otavio Murta Junior (University of Sao Paulo, Brazil)")
 set(EXTENSION_DESCRIPTION "This extension provides the Diffusion Complexity map based for diffusion imaging sequences (assuming DTI imaging protocol). This algorithm results in an diffusion scalar mapping based on the LMC complexity metric, infering micro-structural tissue complexity measurement.")
-set(EXTENSION_ICONURL "https://www.slicer.org/w/img_auth.php/5/58/DiffusionComplexityMap-logo.png")
-set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/w/img_auth.php/4/4c/FA_diff_example.png https://www.slicer.org/w/img_auth.php/d/dc/ADC_diff_example.png https://www.slicer.org/w/img_auth.php/2/2b/DC_diff_example.png https://www.slicer.org/w/img_auth.php/a/ad/Dc_map_gui.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/CSIM-Toolkits/SlicerDiffusionComplexityMap/main/DiffusionComplexityMap.png")
+set(EXTENSION_SCREENSHOTURLS
+  "https://www.slicer.org/w/img_auth.php/4/4c/FA_diff_example.png"
+  "https://www.slicer.org/w/img_auth.php/d/dc/ADC_diff_example.png"
+  "https://www.slicer.org/w/img_auth.php/2/2b/DC_diff_example.png"
+  "https://www.slicer.org/w/img_auth.php/a/ad/Dc_map_gui.png"
+)
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Set `EXTENSION_ICONURL` using the GitHub raw URL instead of the file hosted on the Slicer wiki.

Set `EXTENSION_SCREENSHOTURLS` as a list leveraging support introduced in Slicer/Slicer@1b9bd54b06 (`ENH: Support specifying screenshot URL extension metadata as string or list`, 2024-04-16)

Related pull requests:
* https://github.com/Slicer/ExtensionsIndex/pull/2013